### PR TITLE
feat: add jest test-coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+.idea
+node_modules/
+coverage/
+reports/
+package-lock.json
+.swp
+src/junit.xml
+junit.xml

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,55 @@
+/**
+ * For a detailed explanation regarding each configuration property, visit:
+ * https://jestjs.io/docs/configuration
+ */
+
+/** @type {import('jest').Config} */
+const config = {
+
+  reporters: [
+    'default',
+    ['jest-junit', {outputDirectory: 'reports', outputName: 'report.xml'}],
+  ],
+ 
+  // Automatically clear mock calls, instances, contexts and results before every test
+  clearMocks: true,
+
+  // Indicates whether the coverage information should be collected while executing the test
+  collectCoverage: true,
+
+  // The directory where Jest should output its coverage files
+  coverageDirectory: "coverage",
+
+  // Indicates which provider should be used to instrument code for coverage
+  coverageProvider: "v8",
+
+  // A list of reporter names that Jest uses when writing coverage reports
+  coverageReporters: [
+    "json",
+    "text",
+    "lcov",
+    'text-summary'
+  ],
+
+  // An object that configures minimum threshold enforcement for coverage results
+  coverageThreshold: {
+    global: {
+      statements: 50,
+      functions: 50,
+      branches: 50,
+      lines: 50
+    }
+  },
+
+  // The test environment that will be used for testing
+  testEnvironment: "jest-environment-node",
+
+  // An array of regexp pattern strings that are matched against all source file paths, matched files will skip transformation
+  transformIgnorePatterns: [
+    "/node_modules/",
+    // "\\.pnp\\.[^\\/]+$"
+  ],
+
+};
+
+module.exports = config;

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "start": "node src/index.js",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
-    "test": "jest --ci --reporters=default --reporters=jest-junit --env=node test/unit",
+    "test": "jest",
     "test:int": "jest --ci --reporters=default --reporters=jest-junit --env=node test/integration --forceExit"
   },
   "dependencies": {
@@ -50,7 +50,7 @@
     "eslint": "^7.4.0",
     "eslint-config-airbnb-base": "^14.2.0",
     "eslint-plugin-import": "^2.22.0",
-    "jest": "^27.4.7",
+    "jest": "^27.5.1",
     "jest-junit": "^13.0.0",
     "nock": "^13.0.2",
     "openapi-response-validator": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "start": "node src/index.js",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
-    "test": "jest",
+    "test": "jest --ci --reporters=default --reporters=jest-junit --env=node test/unit",
     "test:int": "jest --ci --reporters=default --reporters=jest-junit --env=node test/integration --forceExit"
   },
   "dependencies": {


### PR DESCRIPTION
Hello,
I have made some changes in this repository to add the test coverage with a text summary. For this, I needed to install jest globally and configure jest.config.js.

So, I have made changes in the ".gitignore" file, created a jest.config.js file, and updated a package along the go.

Now, this is what I am getting as a result, when I run the command `npm test`


![image](https://github.com/user-attachments/assets/056fa6cd-cd72-42ff-b653-9affdfc48cfc)
