### PR TITLE
chore(Ime 468/fix):  json stringify issue

### DIFF
--- a/src/lib/cacheDatabase/index.js
+++ b/src/lib/cacheDatabase/index.js
@@ -86,10 +86,12 @@ async function syncDB({ redisCache, db, logger }) {
 
         if (data.direction === 'INBOUND') {
             if (data.quoteResponse?.body) {
-                data.quoteResponse.body = JSON.parse(data.quoteResponse.body);
+                if(typeof data.quoteResponse.body === 'string')
+                    data.quoteResponse.body = JSON.parse(data.quoteResponse.body);
             }
             if (data.fulfil?.body) {
-                data.fulfil.body = JSON.parse(data.fulfil.body);
+                if(typeof data.fulfil.body === 'string')
+                    data.fulfil.body = JSON.parse(data.fulfil.body);
             }
         }
         return data;
@@ -177,7 +179,9 @@ async function syncDB({ redisCache, db, logger }) {
             // The empty object is initialised for the case in which fxQuoteResponse is empty so we don't have to deal with null errors
             let fx_quote_row = null;
             if(data.fxQuoteRequest){
-                let fxQuoteRequest = JSON.parse(data.fxQuoteRequest.body);
+                let fxQuoteRequest = data.fxQuoteRequest.body;
+                if(typeof data.fxQuoteRequest.body === 'string')
+                    fxQuoteRequest = JSON.parse(fxQuoteRequest);
                 fx_quote_row = {
                     redis_key: key,
                     conversion_request_id: fxQuoteRequest.conversionRequestId,
@@ -353,7 +357,9 @@ async function syncDB({ redisCache, db, logger }) {
                 logger.log('fxQuoteRequest not present on ',key);
             }
             if(data.fxQuoteResponse){
-                const fxQuoteBody = JSON.parse(data.fxQuoteResponse.body);
+                let fxQuoteBody = (data.fxQuoteResponse.body);
+                if(typeof fxQuoteBody === 'string')
+                    fxQuoteBody = JSON.parse(fxQuoteBody);
                 fxQuoteRow.conversion_id = fxQuoteBody.conversionTerms.conversionId;
                 fxQuoteRow.initiating_fsp = fxQuoteBody.conversionTerms.initiatingFsp;
                 fxQuoteRow.counter_party_fsp = fxQuoteBody.conversionTerms.counterPartyFsp;

--- a/src/lib/model/FxpConversion.js
+++ b/src/lib/model/FxpConversion.js
@@ -301,8 +301,7 @@ class FxpConversion {
                   headers: raw.fxTransferRequest && raw.fxTransferRequest.headers,
                   body:
                   raw.fxTransferRequest &&
-                  raw.fxTransferRequest.body &&
-                  JSON.parse(raw.fxTransferRequest.body),
+                  raw.fxTransferRequest.body
               }
               : raw.fxPrepare,
                 fxTransferFulfil:

--- a/src/lib/model/Transfer.js
+++ b/src/lib/model/Transfer.js
@@ -248,6 +248,11 @@ class Transfer {
         // Condition for when exchangeRate calculation is not possible , also to avoid divide by zero error
         if(!sourceAmount || !targetAmount || ((sourceAmount - totalSourceCharges) === 0))
             return null;
+        // If the totalTargetCharges and totalSourceCharges are null because of there being no charges the result should not evaluate to Nan. To avoid that checking if the charge is an empty string and setting it to 0 before the calculations
+        if(isNaN(totalTargetCharges))
+            totalTargetCharges = 0;
+        if(isNaN(totalSourceCharges))
+            totalSourceCharges = 0;
         return ((targetAmount - totalTargetCharges)/(sourceAmount - totalSourceCharges)).toFixed(4);
     }
 


### PR DESCRIPTION
- Add conditions before doing JSON.parse for redis cache being loaded
- Not crashing with the payload being loaded
- fix: nan being shown in transferterms for exchange rate when the charges are nan
- Changes are made to account for the change in the format the data is being stored in the redis because of the changes in sdk-scheme-adapter.